### PR TITLE
Add C project skeleton with Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,52 +1,18 @@
-# Prerequisites
-*.d
-
-# Object files
+# Compiled object files
 *.o
-*.ko
-*.obj
-*.elf
-
-# Linker output
-*.ilk
-*.map
-*.exp
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Libraries
-*.lib
-*.a
-*.la
-*.lo
-
-# Shared objects (inc. Windows DLLs)
-*.dll
-*.so
-*.so.*
-*.dylib
 
 # Executables
 *.exe
 *.out
-*.app
-*.i*86
-*.x86_64
-*.hex
+bin/
+
+# Libraries
+*.a
+*.so
+*.dll
 
 # Debug files
-*.dSYM/
-*.su
-*.idb
-*.pdb
+*.dSYM
 
-# Kernel Module Compile Results
-*.mod*
-*.cmd
-.tmp_versions/
-modules.order
-Module.symvers
-Mkfile.old
-dkms.conf
+# Editor files
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+CC ?= gcc
+CFLAGS ?= -Wall -Wextra -std=c99
+
+SRC := $(wildcard src/*.c)
+BIN := bin/mathquiz
+
+$(BIN): $(SRC)
+	@mkdir -p $(dir $(BIN))
+	$(CC) $(CFLAGS) $(SRC) -o $(BIN)
+
+.PHONY: clean
+clean:
+	$(RM) $(BIN)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Mathe-Spiel
+
+A simple math quiz project implemented in C.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+This directory is intended for project documentation.

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+    printf("Math quiz initialized.\n");
+    return 0;
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+Place test cases here.


### PR DESCRIPTION
## Summary
- create `src`, `docs`, `tests` directories
- add simple C `main.c`
- add cross-platform Makefile compiling all `src/*.c` to `bin/mathquiz`
- simplify `.gitignore` for common C artifacts
- update README and add docs/tests placeholders

## Testing
- `make clean`
- `make`
- `./bin/mathquiz`

------
https://chatgpt.com/codex/tasks/task_e_686139452b0c83219ea11b6655bc85b8