### PR TITLE
Improve build config and docs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: LLVM
+IndentWidth: 4

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ bin/
 
 # Editor files
 *~
+
+# Documentation output
+docs/html/

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,7 @@
+# Doxyfile for Mathe-Spiel
+PROJECT_NAME = "Mathe-Spiel"
+OUTPUT_DIRECTORY = docs/html
+INPUT = src
+RECURSIVE = YES
+GENERATE_HTML = YES
+GENERATE_LATEX = NO

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC ?= gcc
-CFLAGS ?= -Wall -Wextra -std=c99
+CFLAGS ?= -Wall -Wextra -pedantic -std=c99
 
 SRC := $(wildcard src/*.c)
 BIN := bin/mathquiz


### PR DESCRIPTION
## Summary
- configure clang-format
- enable `-Wall -Wextra -pedantic` in the build
- add Doxygen configuration generating docs in `docs/html`
- ignore generated documentation output

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6861420923408321b17b51ca5646a5f5