### PR TITLE
Add leaderboard saving and menu loop

### DIFF
--- a/src/game_logic.c
+++ b/src/game_logic.c
@@ -5,18 +5,18 @@
 #include <stdlib.h>
 #include <time.h>
 
-void play_game(void) {
+int play_game(void) {
     size_t total = qb_count();
     if (total == 0) {
         printf("Keine Fragen verf\303\274gbar.\n");
-        return;
+        return 0;
     }
 
     size_t count = total < 10 ? total : 10;
     size_t *indices = malloc(total * sizeof(size_t));
     if (!indices) {
         printf("Speicherfehler.\n");
-        return;
+        return 0;
     }
 
     for (size_t i = 0; i < total; i++) {
@@ -58,5 +58,7 @@ void play_game(void) {
 
     free(indices);
     printf("\nSpiel beendet. Punkte: %d von %zu.\n", score, count);
+
+    return score;
 }
 

--- a/src/game_logic.h
+++ b/src/game_logic.h
@@ -1,6 +1,11 @@
 #ifndef GAME_LOGIC_H
 #define GAME_LOGIC_H
 
-void play_game(void);
+/**
+ * @brief Run a quiz round.
+ *
+ * @return Achieved score.
+ */
+int play_game(void);
 
 #endif /* GAME_LOGIC_H */

--- a/src/main.c
+++ b/src/main.c
@@ -1,9 +1,73 @@
 #include <stdio.h>
+#include "game_logic.h"
+#include "leaderboard.h"
 
-/* Declaration from ui_menu.c */
-void ui_main_menu(void);
+#define LB_FILE "leaderboard.txt"
+
+static void show_menu(void) {
+    printf("\nHauptmen\303\274\n");
+    printf("1. Spielen\n");
+    printf("2. Bestenliste anzeigen\n");
+    printf("3. Bestenliste zur\303\274cksetzen\n");
+    printf("4. Beenden\n");
+    printf("Auswahl: ");
+}
+
+static void show_leaderboard(void) {
+    if (lb_load(LB_FILE) != 0) {
+        printf("Noch keine Bestenliste vorhanden.\n");
+        return;
+    }
+    size_t count = lb_count();
+    const LBEntry *entries = lb_entries();
+    printf("\nBestenliste:\n");
+    for (size_t i = 0; i < count; i++) {
+        printf("%zu. %s - %d\n", i + 1, entries[i].name, entries[i].score);
+    }
+}
 
 int main(void) {
-    ui_main_menu();
-    return 0;
+    lb_load(LB_FILE);
+    int choice = 0;
+    while (1) {
+        show_menu();
+        if (scanf("%d", &choice) != 1) {
+            int c;
+            while ((c = getchar()) != '\n' && c != EOF) {}
+            printf("Ung\303\274ltige Eingabe. Bitte Zahl zwischen 1 und 4 eingeben.\n");
+            continue;
+        }
+        switch (choice) {
+            case 1: {
+                int score = play_game();
+                char name[LB_NAME_LEN];
+                printf("Bitte Namen eingeben: ");
+                if (scanf("%63s", name) != 1) {
+                    int c; while ((c = getchar()) != '\n' && c != EOF) {}
+                    printf("Ung\303\274ltige Eingabe. Ergebnis wird nicht gespeichert.\n");
+                } else {
+                    lb_add(name, score);
+                    lb_save(LB_FILE);
+                }
+                break;
+            }
+            case 2:
+                show_leaderboard();
+                break;
+            case 3:
+                if (lb_reset(LB_FILE) == 0) {
+                    printf("Bestenliste zur\303\274ckgesetzt.\n");
+                } else {
+                    printf("Fehler beim Zur\303\274cksetzen der Bestenliste.\n");
+                }
+                break;
+            case 4:
+                lb_save(LB_FILE);
+                printf("Programm wird beendet.\n");
+                return 0;
+            default:
+                printf("Bitte Zahl zwischen 1 und 4 eingeben.\n");
+                break;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- return score from `play_game`
- integrate leaderboard operations in `main.c`
- menu now saves results and can display or reset the leaderboard

## Testing
- `make`
- ran `./bin/mathquiz` with sample inputs

------
https://chatgpt.com/codex/tasks/task_e_6861417781a08321b119a98440eb31ee